### PR TITLE
MailSenderの仕様変更に対応

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ apply plugin: "io.spring.dependency-management"
 
 dependencyManagement {
   imports {
-    mavenBom 'com.nablarch.profile:nablarch-bom:5u8'
+    mavenBom 'com.nablarch.profile:nablarch-bom:5u9'
   }
   applyMavenExclusions false
 }
@@ -68,8 +68,8 @@ dependencies {
   )
 
   testCompile 'com.nablarch.framework:nablarch-testing'
-  testCompile 'junit:junit:4.10'
   testCompile 'org.hamcrest:hamcrest-all:1.3'
+  testCompile 'junit:junit:4.10'
 
   testRuntime 'com.nablarch.framework:nablarch-common-idgenerator-jdbc'
   testRuntime 'com.nablarch.framework:nablarch-common-jdbc'

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 
 group = 'com.nablarch.integration'
-version = '1.0.0'
+version = '1.1.0'
 description = 'bouncycastleによる電子署名付きメール送信機能の実装'
 
 buildscript {
@@ -69,7 +69,7 @@ dependencies {
 
   testCompile 'com.nablarch.framework:nablarch-testing'
   testCompile 'org.hamcrest:hamcrest-all:1.3'
-  testCompile 'junit:junit:4.10'
+  testCompile 'junit:junit:4.12'
 
   testRuntime 'com.nablarch.framework:nablarch-common-idgenerator-jdbc'
   testRuntime 'com.nablarch.framework:nablarch-common-jdbc'

--- a/main/java/please/change/me/common/mail/smime/SMIMESignedMailSender.java
+++ b/main/java/please/change/me/common/mail/smime/SMIMESignedMailSender.java
@@ -70,13 +70,14 @@ public class SMIMESignedMailSender extends MailSender {
         String mailSendPatternId = context.getSessionScopedVar("mailSendPatternId");
         Map<String, CertificateWrapper> certificateChain = SystemRepository.get(CERTIFICATE_REPOSITORY_KEY);
         CertificateWrapper certificateWrapper = certificateChain.get(mailSendPatternId);
+        if (certificateWrapper == null) {
+            throw createProcessAbnormalEnd(
+                    new IllegalStateException(
+                            String.format("No certification setting. mailSendPatternId=[%s]", mailSendPatternId)),
+                    mailRequest);
+        }
 
         try {
-            if (certificateWrapper == null) {
-                throw new IllegalStateException(
-                        String.format("No certification setting. mailSendPatternId=[%s]", mailSendPatternId));
-            }
-
             // 電子署名を生成するジェネレータ
             SMIMESignedGenerator smimeSignedGenerator = new SMIMESignedGenerator();
 
@@ -109,8 +110,6 @@ public class SMIMESignedMailSender extends MailSender {
         } catch (CertificateParsingException e) {
             throw createProcessAbnormalEnd(e, mailRequest);
         } catch (SMIMEException e) {
-            throw createProcessAbnormalEnd(e, mailRequest);
-        } catch (IllegalStateException e) {
             throw createProcessAbnormalEnd(e, mailRequest);
         }
     }

--- a/main/java/please/change/me/common/mail/smime/SMIMESignedMailSender.java
+++ b/main/java/please/change/me/common/mail/smime/SMIMESignedMailSender.java
@@ -17,12 +17,11 @@ import javax.mail.internet.MimeMultipart;
 import javax.mail.util.ByteArrayDataSource;
 
 import nablarch.common.mail.MailAttachedFileTable;
-import nablarch.common.mail.MailConfig;
 import nablarch.common.mail.MailRequestTable;
 import nablarch.common.mail.MailSender;
+import nablarch.common.mail.SendMailException;
 import nablarch.core.repository.SystemRepository;
 import nablarch.fw.ExecutionContext;
-import nablarch.fw.results.TransactionAbnormalEnd;
 
 import org.bouncycastle.asn1.ASN1EncodableVector;
 import org.bouncycastle.asn1.cms.AttributeTable;
@@ -97,12 +96,10 @@ public class SMIMESignedMailSender extends MailSender {
                 mimeMessage.setContent(smimeSignedGenerator.generate(smimeBody));
             }
         } catch (Exception e) {
-            MailConfig mailConfig = SystemRepository.get("mailConfig");
-            String mailRequestId = mailRequest.getMailRequestId();
-
-            throw new TransactionAbnormalEnd(
-                    mailConfig.getAbnormalEndExitCode(), e,
-                    mailConfig.getSendFailureCode(), mailRequestId);
+            throw new SendMailException(
+                    String.format("Failed to add contents in the mail. mailRequestId=[%s]",
+                            mailRequest.getMailRequestId()),
+                    e);
         }
     }
 

--- a/main/java/please/change/me/common/mail/smime/SMIMESignedMailSender.java
+++ b/main/java/please/change/me/common/mail/smime/SMIMESignedMailSender.java
@@ -72,6 +72,11 @@ public class SMIMESignedMailSender extends MailSender {
         CertificateWrapper certificateWrapper = certificateChain.get(mailSendPatternId);
 
         try {
+            if (certificateWrapper == null) {
+                throw new IllegalStateException(
+                        String.format("No certification setting. mailSendPatternId=[%s]", mailSendPatternId));
+            }
+
             // 電子署名を生成するジェネレータ
             SMIMESignedGenerator smimeSignedGenerator = new SMIMESignedGenerator();
 
@@ -104,6 +109,8 @@ public class SMIMESignedMailSender extends MailSender {
         } catch (CertificateParsingException e) {
             throw createProcessAbnormalEnd(e, mailRequest);
         } catch (SMIMEException e) {
+            throw createProcessAbnormalEnd(e, mailRequest);
+        } catch (IllegalStateException e) {
             throw createProcessAbnormalEnd(e, mailRequest);
         }
     }

--- a/test/java/please/change/me/common/mail/smime/SMIMESignedMailSenderTest.java
+++ b/test/java/please/change/me/common/mail/smime/SMIMESignedMailSenderTest.java
@@ -516,11 +516,12 @@ public class SMIMESignedMailSenderTest extends MailTestSupport {
                 "-mailSendPatternId", "05");
         int exitCode = Main.execute(commandLine);
 
-        assertThat("リトライし上限に達して異常終了する。", exitCode, is(180));
+        assertThat("設定不備なので1通目でプロセスは異常終了する。", exitCode, is(199));
 
         // ログアサート
         assertLog("メール送信要求が 2 件あります。");
-        assertLog("[180 ProcessAbnormalEnd] An error happened");
+        assertLog("No certification setting. mailSendPatternId=[05]");
+        assertLog("[199 ProcessAbnormalEnd] メール送信失敗：メールリクエストID 101");
 
         PreparedStatement statement = testDbConnection.prepareStatement(
                 "select * from mail_send_request order by mail_request_id");
@@ -531,7 +532,7 @@ public class SMIMESignedMailSenderTest extends MailTestSupport {
         assertThat(rs.getObject("sending_timestamp"), is(nullValue()));
         assertThat(rs.next(), is(true));
         assertThat(rs.getString("mail_request_id"), is("102"));
-        assertThat(rs.getString("status"), is("Z"));
+        assertThat(rs.getString("status"), is("A"));
         assertThat(rs.getObject("sending_timestamp"), is(nullValue()));
     }
 }

--- a/test/java/please/change/me/common/mail/smime/SMIMESignedMailSenderTest.java
+++ b/test/java/please/change/me/common/mail/smime/SMIMESignedMailSenderTest.java
@@ -455,7 +455,7 @@ public class SMIMESignedMailSenderTest extends MailTestSupport {
                 "-mailSendPatternId", "02");
         int exitCode = Main.execute(commandLine);
 
-        assertThat(exitCode, is(199));
+        assertThat("送信失敗でもバッチは正常終了。",exitCode, is(0));
 
         // ログアサート
         assertLog("メール送信要求が 1 件あります。");

--- a/test/resources/log.properties
+++ b/test/resources/log.properties
@@ -16,5 +16,5 @@ loggers.mail.writerNames=mail
 # other
 loggers.other.nameRegex=.*
 loggers.other.level=INFO
-loggers.other.writerNames=stdout
+loggers.other.writerNames=mail,stdout
 

--- a/test/resources/please/change/me/common/mail/smime/SmimeSignedMailSenderResidentTest.xml
+++ b/test/resources/please/change/me/common/mail/smime/SmimeSignedMailSenderResidentTest.xml
@@ -41,6 +41,21 @@
     <component class="please.change.me.common.mail.testsupport.MailExceptionHandler" />
     <!-- スレッドコンテキスト設定ハンドラ -->
     <component-ref name="threadContextHandler" />
+    <!-- リトライハンドラ -->
+    <component name="retryHandler" class="nablarch.fw.handler.RetryHandler">
+      <property name="retryLimitExceededFailureCode" value="" />
+      <property name="retryContextFactory">
+        <component class="nablarch.fw.handler.retry.CountingRetryContextFactory">
+          <property name="retryCount" value="3" />          <!-- 3回リトライを行う -->
+          <property name="retryIntervals" value="500" />   <!-- リトライを実行するまで0.5秒待機する -->
+        </component>
+      </property>
+    </component>
+    <!-- 常駐化ハンドラ (Retryも含めてテストする) -->
+    <component name="processResidentHandler"
+        class="nablarch.fw.handler.ProcessResidentHandler">
+      <property name="dataWatchInterval" value="1000" />
+    </component>
     <!-- データベース接続ハンドラ -->
     <component-ref name="dbConnectionManagementHandler" />
     <!--トランザクションマネージャ -->

--- a/test/resources/please/change/me/common/mail/smime/SmimeSignedMailSenderResidentTest.xml
+++ b/test/resources/please/change/me/common/mail/smime/SmimeSignedMailSenderResidentTest.xml
@@ -46,7 +46,7 @@
       <property name="retryLimitExceededFailureCode" value="" />
       <property name="retryContextFactory">
         <component class="nablarch.fw.handler.retry.CountingRetryContextFactory">
-          <property name="retryCount" value="3" />          <!-- 3回リトライを行う -->
+          <property name="retryCount" value="1" />          <!-- 1回リトライを行う -->
           <property name="retryIntervals" value="500" />   <!-- リトライを実行するまで0.5秒待機する -->
         </component>
       </property>

--- a/test/resources/please/change/me/common/mail/smime/SmimeSignedMailSenderTest.xml
+++ b/test/resources/please/change/me/common/mail/smime/SmimeSignedMailSenderTest.xml
@@ -24,6 +24,18 @@
     <property name="interval" value="500" />
   </component>
 
+  <!-- TransactionFactoryの設定 -->
+  <component name="jdbcTransactionFactory" class="nablarch.core.db.transaction.JdbcTransactionFactory">
+    <property name="isolationLevel" value="READ_COMMITTED" />
+  </component>
+
+  <!-- ステータス更新用のトランザクション -->
+  <component name="statusUpdateTransaction" class="nablarch.core.db.transaction.SimpleDbTransactionManager">
+    <property name="dbTransactionName" value="statusUpdateTransaction" />
+    <property name="connectionFactory" ref="connectionFactory" />
+    <property name="transactionFactory" ref="jdbcTransactionFactory" />
+  </component>
+
   <!-- ハンドラキュー構成 -->
   <list name="handlerQueue">
     <!-- ステータスコードを終了コードに変換するハンドラ -->


### PR DESCRIPTION
以下を修正
* ステータス更新用のトランザクション定義をxmlに追加
* ExceptionをTransactionAbnormalEndにラップしていた箇所をSendMailExceptionにラップするよう変更
* 送信失敗は正常終了とする仕様変更に testAttachedFileContextTypeNull を対応
* bulid.gradleのnablarch-bomのバージョンを5u9に更新
* build.gradleのhamcrestとjunitの依存関係に合わせて順序を変更